### PR TITLE
fix: avoid shell interpolation in release notes

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -105,11 +105,11 @@ Packaged macOS release of $APP_NAME.
 ### Artifact
 - $ASSET_NAME
 - $(basename "$CHECKSUM_FILE")
-- SHA-256: \`$SHA\`
+- SHA-256: $SHA
 
 ### Notes
 - CPU temperature is best-effort and may fall back to thermal state when no supported helper tool is available.
-- This release ships as a macOS `.app` zipped artifact.
+- This release ships as a macOS .app zipped artifact.
 EOF
 
 if [[ "$TAG_EXISTS_LOCAL" -eq 0 ]]; then


### PR DESCRIPTION
## Summary\n- stop using markdown backticks in the release notes heredoc where zsh can treat them as command substitution\n- keep release notes content equivalent while avoiding the spurious '.app' command-not-found error\n\n## Testing\n- zsh -n release.sh\n- heredoc release notes sanity check\n