### PR TITLE
fix: reduce menu-open refresh churn and preserve install version

### DIFF
--- a/Sources/ProcessBarMonitor/MonitorViewModel.swift
+++ b/Sources/ProcessBarMonitor/MonitorViewModel.swift
@@ -135,10 +135,10 @@ final class MonitorViewModel: ObservableObject {
         isRefreshing = true
         defer { isRefreshing = false }
 
+        let processIntervalElapsed = Date().timeIntervalSince(lastProcessRefresh) >= processRefreshInterval
         let shouldRefreshProcesses = forceProcesses
-            || isMenuExpanded
             || allProcesses.isEmpty
-            || Date().timeIntervalSince(lastProcessRefresh) >= processRefreshInterval
+            || (isMenuExpanded && processIntervalElapsed)
 
         async let summaryTask = metricsProvider.snapshot(temperatureMode: temperatureMode)
         async let processTask: Result<[ProcessStat], Error>? = shouldRefreshProcesses ? processSnapshotResult() : nil

--- a/install_app.sh
+++ b/install_app.sh
@@ -6,7 +6,7 @@ TARGET_DIR="$HOME/Applications"
 
 pkill -f '/Users/mn/Applications/ProcessBarMonitor.app/Contents/MacOS/ProcessBarMonitor' || true
 pkill -f '/Users/mn/.openclaw/workspace/ProcessBarMonitor/.build/.*/ProcessBarMonitor' || true
-"$ROOT/build_app.sh"
+"$ROOT/build_app.sh" "$@"
 mkdir -p "$TARGET_DIR"
 rm -rf "$TARGET_DIR/$APP_NAME"
 cp -R "$ROOT/dist/$APP_NAME" "$TARGET_DIR/$APP_NAME"


### PR DESCRIPTION
## Summary\n- respect the process refresh interval when the menu is open instead of refreshing process snapshots every summary tick\n- forward install_app.sh arguments into build_app.sh so installs preserve the requested version/build\n- verified the installed app now reports version 1.0.4-local (2) after install\n\n## Validation\n- swift build\n- ./build_app.sh 1.0.4-local 1 --configuration release\n- ./install_app.sh 1.0.4-local 2 --configuration release\n- lightweight sample profiling on the installed app