### PR TITLE
ci: opt GitHub Actions into Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Show toolchain versions
         run: |
@@ -38,7 +38,7 @@ jobs:
           shasum -a 256 release/ProcessBarMonitor-ci-macOS.zip > release/ProcessBarMonitor-ci-SHA256SUMS.txt
 
       - name: Upload app artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ProcessBarMonitor-macOS
           path: |


### PR DESCRIPTION
## Summary\n- opt JavaScript-based GitHub Actions into Node 24 now\n- remove the deprecation warning path before GitHub flips the default runtime\n- keep the current workflow structure unchanged\n\n## Why\nGitHub is warning that actions such as checkout and upload-artifact currently run on Node 20 and will move to Node 24 by default. This workflow is simple, so opting in now is the lowest-risk way to verify compatibility early.\n\n## Validation\n- trigger CI on this PR\n- confirm the existing build workflow still passes under Node 24