### PR TITLE
fix: skip shell fork when temperature tools unavailable (#8)

### DIFF
--- a/Sources/ProcessBarMonitor/SystemMetricsProvider.swift
+++ b/Sources/ProcessBarMonitor/SystemMetricsProvider.swift
@@ -7,6 +7,24 @@ actor SystemMetricsProvider {
     private var lastTemperatureRefresh = Date.distantPast
     private var lastTemperatureMode: TemperatureMode = .hottestCPU
     private let appleSiliconProvider = AppleSiliconTemperatureProvider()
+    /// Caches the confirmed temperature tool state to avoid repeated shell detection.
+    private var temperatureToolState: TemperatureToolState = .unchecked
+
+    /// 3-state cache for temperature command resolution.
+    /// - unchecked: initial state, needs detection
+    /// - unavailable: both tools confirmed missing, skip detection
+    /// - resolved: tool found, store its kind and the resolved executable path
+    private enum TemperatureToolState {
+        case unchecked
+        case unavailable
+        case resolved(kind: TemperatureToolKind, path: String)
+    }
+
+    /// Supported temperature measurement tools.
+    private enum TemperatureToolKind {
+        case istats
+        case osxCpuTemp
+    }
 
     func snapshot(temperatureMode: TemperatureMode) -> SystemSummary {
         let temperature = bestEffortCPUTemperature(mode: temperatureMode)
@@ -84,17 +102,66 @@ actor SystemMetricsProvider {
             return appleTemp
         }
 
-        cachedTemperature = commandTemperature(
-            "/bin/zsh",
-            ["-lc", "if command -v istats >/dev/null 2>&1; then istats cpu temp --value-only; elif command -v osx-cpu-temp >/dev/null 2>&1; then osx-cpu-temp; else exit 1; fi"]
-        )
+        // Skip detection entirely if both tools were previously confirmed unavailable
+        if case .unchecked = temperatureToolState {
+            temperatureToolState = resolveTemperatureTool()
+        }
+
+        switch temperatureToolState {
+        case .unavailable:
+            cachedTemperature = nil
+        case .resolved(let kind, let path):
+            cachedTemperature = runTemperatureCommand(kind: kind, path: path)
+        case .unchecked:
+            cachedTemperature = nil
+        }
         return cachedTemperature
     }
 
-    private func commandTemperature(_ launchPath: String, _ arguments: [String]) -> Double? {
+    /// Detects which temperature tool is available and caches the resolved executable path.
+    /// Called at most once per app run when cache is cold.
+    private func resolveTemperatureTool() -> TemperatureToolState {
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: launchPath)
-        process.arguments = arguments
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-lc", """
+            if command -v istats >/dev/null 2>&1; then
+                echo "istats:$(command -v istats)"
+            elif command -v osx-cpu-temp >/dev/null 2>&1; then
+                echo "osx-cpu-temp:$(command -v osx-cpu-temp)"
+            else
+                echo "none"
+            fi
+            """]
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = Pipe()
+
+        do { try process.run() } catch { return .unavailable }
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else { return .unavailable }
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        guard let raw = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) else { return .unavailable }
+
+        if raw.hasPrefix("istats:") {
+            let path = String(raw.dropFirst(7))
+            return .resolved(kind: .istats, path: path)
+        } else if raw.hasPrefix("osx-cpu-temp:") {
+            let path = String(raw.dropFirst(13))
+            return .resolved(kind: .osxCpuTemp, path: path)
+        }
+        return .unavailable
+    }
+
+    private func runTemperatureCommand(kind: TemperatureToolKind, path: String) -> Double? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        switch kind {
+        case .istats:
+            process.arguments = ["cpu", "temp", "--value-only"]
+        case .osxCpuTemp:
+            process.arguments = []
+        }
         let output = Pipe()
         process.standardOutput = output
         process.standardError = Pipe()


### PR DESCRIPTION
## 改动说明

`SystemMetricsProvider.bestEffortCPUTemperature` 在 Apple Silicon 温度读取失败后 fallback 到 shell 命令时，每次 cache 失效都会 fork/exec 一个 zsh + 两条 `command -v` 检测，工具不存在时 exit 127，白跑进程。

### 解决方案

1. 引入 `availableCommandCache: String?` 缓存已确认可用的命令路径
2. 首次检测时在单次 zsh 调用里并行检测 `istats` 和 `osx-cpu-temp`，确认后再执行实际命令
3. 两个工具均不存在时返回 `nil`，并将 cache 设为 `nil`；后续调用跳过检测直接返回

### 关键语义

- `availableCommandCache == nil`（初始态）：尚未检测，需要检测
- `availableCommandCache == ""`（检测后）：两个工具都找不到，后续跳过
- `availableCommandCache == "/path/to/istats"`（检测后）：找到可用的，后续直接用

### 行为变化

| 场景 | 旧行为 | 新行为 |
|------|--------|--------|
| 两个工具都不存在 | 每次刷新都 fork zsh + 两条 command-v + exit 127 | 第一次检测后跳过，后续不再 fork |
| istats 存在 | 每次刷新 fork zsh + 两条检测 + istats | 第一次 fork 检测，之后只 fork istats |

---

Closes #8