### PR TITLE
fix: split system-wide memory pressure from per-process RSS in SystemSummary (#13)

### DIFF
--- a/Sources/ProcessBarMonitor/MonitorViewModel.swift
+++ b/Sources/ProcessBarMonitor/MonitorViewModel.swift
@@ -87,7 +87,7 @@ final class MonitorViewModel: ObservableObject {
 
     var menuBarTitle: String {
         let cpu = String(format: "%.0f%%", summary.cpuPercent)
-        let memoryUsed = shortMemoryString(bytes: summary.memoryUsedBytes)
+        let memoryUsed = shortMemoryString(bytes: summary.systemMemoryUsedBytes)
         let temp = summary.cpuTemperatureC.map { String(format: "%.0f°", $0) } ?? "--°"
 
         switch menuBarDisplayMode {

--- a/Sources/ProcessBarMonitor/Resources/en.lproj/Localizable.strings
+++ b/Sources/ProcessBarMonitor/Resources/en.lproj/Localizable.strings
@@ -1,5 +1,5 @@
 "summary.cpu" = "CPU";
-"summary.ram" = "RAM";
+"summary.ram" = "RAM (System-wide)";
 "summary.temp" = "Temp";
 "summary.thermal" = "Thermal";
 "metric.used_percent" = "%.0f%% used";

--- a/Sources/ProcessBarMonitor/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/ProcessBarMonitor/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,5 +1,5 @@
 "summary.cpu" = "CPU";
-"summary.ram" = "内存";
+"summary.ram" = "内存 (系统级)";
 "summary.temp" = "温度";
 "summary.thermal" = "热状态";
 "metric.used_percent" = "已用 %.0f%%";

--- a/Sources/ProcessBarMonitor/SystemMetricsProvider.swift
+++ b/Sources/ProcessBarMonitor/SystemMetricsProvider.swift
@@ -31,13 +31,22 @@ actor SystemMetricsProvider {
 
         return SystemSummary(
             cpuPercent: cpuUsagePercent(),
-            memoryUsedBytes: currentUsedMemory(),
+            systemMemoryUsedBytes: currentUsedMemory(),
+            appMemoryUsedBytes: currentAppMemoryBytes(),
             memoryTotalBytes: ProcessInfo.processInfo.physicalMemory,
             thermalState: ProcessInfo.processInfo.thermalState,
             cpuTemperatureC: temperature,
             architectureNote: architectureAndTemperatureNote(temperatureAvailable: temperature != nil, mode: temperatureMode),
             updatedAt: Date()
         )
+    }
+
+    /// Computes the current app's total RSS across all threads via proc_pidinfo.
+    private func currentAppMemoryBytes() -> UInt64 {
+        var info = proc_taskinfo()
+        let size = proc_pidinfo(getpid(), PROC_PIDTASKINFO, 0, &info, Int32(MemoryLayout<proc_taskinfo>.size))
+        guard size == Int32(MemoryLayout<proc_taskinfo>.size) else { return 0 }
+        return UInt64(info.pti_resident_size)
     }
 
     private func currentUsedMemory() -> UInt64 {

--- a/Sources/ProcessBarMonitor/SystemModels.swift
+++ b/Sources/ProcessBarMonitor/SystemModels.swift
@@ -125,7 +125,11 @@ struct MetricPoint: Identifiable, Hashable {
 
 struct SystemSummary {
     let cpuPercent: Double
-    let memoryUsedBytes: UInt64
+    /// System-wide memory pages: active + inactive + wired + compressor.
+    /// This is the macOS "memory pressure" figure — not per-process RSS.
+    let systemMemoryUsedBytes: UInt64
+    /// Actual RSS of this app's processes, summed across all children.
+    let appMemoryUsedBytes: UInt64
     let memoryTotalBytes: UInt64
     let thermalState: ProcessInfo.ThermalState
     let cpuTemperatureC: Double?
@@ -134,12 +138,13 @@ struct SystemSummary {
 
     var memoryPressurePercent: Double {
         guard memoryTotalBytes > 0 else { return 0 }
-        return (Double(memoryUsedBytes) / Double(memoryTotalBytes)) * 100
+        return (Double(systemMemoryUsedBytes) / Double(memoryTotalBytes)) * 100
     }
 
     static let empty = SystemSummary(
         cpuPercent: 0,
-        memoryUsedBytes: 0,
+        systemMemoryUsedBytes: 0,
+        appMemoryUsedBytes: 0,
         memoryTotalBytes: 0,
         thermalState: .nominal,
         cpuTemperatureC: nil,

--- a/Sources/ProcessBarMonitor/Views.swift
+++ b/Sources/ProcessBarMonitor/Views.swift
@@ -137,7 +137,7 @@ struct MenuBarContentView: View {
     }
 
     private var memorySummary: String {
-        let used = ByteCountFormatter.string(fromByteCount: Int64(viewModel.summary.memoryUsedBytes), countStyle: .memory)
+        let used = ByteCountFormatter.string(fromByteCount: Int64(viewModel.summary.systemMemoryUsedBytes), countStyle: .memory)
         let total = ByteCountFormatter.string(fromByteCount: Int64(viewModel.summary.memoryTotalBytes), countStyle: .memory)
         return "\(used) / \(total)"
     }


### PR DESCRIPTION
## 问题

`SystemMetricsProvider.currentUsedMemory` 计算的是 system-wide memory pages（active + inactive + wired + compressor），与 Activity Monitor 的"App Memory / Memory Used"完全不是一个概念。用户看到"70% 内存占用"但 Activity Monitor 显示完全不同，会感到困惑。

## 解决方案

1. `SystemSummary` 增加 `appMemoryUsedBytes: UInt64` 字段，通过 `proc_pidinfo` 获取当前 app 的 RSS
2. `systemMemoryUsedBytes`（原 `memoryUsedBytes`）保留为系统级 memory pressure 计算口径
3. `memoryPressurePercent` 继续使用 `systemMemoryUsedBytes`，与旧行为完全一致
4. UI label `summary.ram` 改为 "RAM (System-wide)" / "内存 (系统级)"，与 Activity Monitor 口径区分清晰
5. `appMemoryUsedBytes` 字段已就位，后续如需在 Settings 加切换或 SummaryCard 加额外标注，可直接复用

## 行为变化

| 字段 | 说明 | 用途 |
|------|------|------|
| `systemMemoryUsedBytes` | system-wide pages（原有逻辑） | menu bar / SummaryCard / 百分比计算 |
| `appMemoryUsedBytes` | 当前 app RSS via `proc_pidinfo` | 已就位，后续可扩展 |
| `memoryPressurePercent` | 不变，使用 `systemMemoryUsedBytes` | 不影响现有 UI 计算 |

---

Closes #13