### PR TITLE
feat: wire SettingsView to the Settings scene (#17)

### DIFF
--- a/Sources/ProcessBarMonitor/ProcessBarMonitorApp.swift
+++ b/Sources/ProcessBarMonitor/ProcessBarMonitorApp.swift
@@ -22,7 +22,7 @@ struct ProcessBarMonitorApp: App {
         .menuBarExtraStyle(.window)
 
         Settings {
-            EmptyView()
+            SettingsView(viewModel: viewModel)
         }
     }
 }

--- a/Sources/ProcessBarMonitor/Resources/en.lproj/Localizable.strings
+++ b/Sources/ProcessBarMonitor/Resources/en.lproj/Localizable.strings
@@ -62,3 +62,5 @@
 "button.copy_diagnostics" = "Copy Diagnostics";
 "status.diagnostics_copied" = "Diagnostics copied to clipboard.";
 "status.diagnostics_copy_failed" = "Failed to copy diagnostics.";
+"settings.section.display" = "Display";
+"settings.section.startup" = "Startup";

--- a/Sources/ProcessBarMonitor/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/ProcessBarMonitor/Resources/zh-Hans.lproj/Localizable.strings
@@ -62,3 +62,5 @@
 "button.copy_diagnostics" = "复制诊断信息";
 "status.diagnostics_copied" = "诊断信息已复制到剪贴板。";
 "status.diagnostics_copy_failed" = "复制诊断信息失败。";
+"settings.section.display" = "显示";
+"settings.section.startup" = "启动";

--- a/Sources/ProcessBarMonitor/SettingsView.swift
+++ b/Sources/ProcessBarMonitor/SettingsView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject var viewModel: MonitorViewModel
+
+    var body: some View {
+        Form {
+            Section {
+                Picker(L10n.string("picker.menu_bar"), selection: $viewModel.menuBarDisplayMode) {
+                    ForEach(MenuBarDisplayMode.allCases) { mode in
+                        Text(mode.title).tag(mode)
+                    }
+                }
+
+                Picker(L10n.string("picker.temperature"), selection: $viewModel.temperatureMode) {
+                    ForEach(TemperatureMode.allCases) { mode in
+                        Text(mode.title).tag(mode)
+                    }
+                }
+
+                Picker(L10n.string("picker.rows"), selection: $viewModel.processLimit) {
+                    Text("5").tag(5)
+                    Text("8").tag(8)
+                    Text("12").tag(12)
+                    Text("20").tag(20)
+                }
+                .onChange(of: viewModel.processLimit) { _ in
+                    viewModel.recomputeVisibleProcesses()
+                }
+            } header: {
+                Text(L10n.string("settings.section.display"))
+            }
+
+            Section {
+                Toggle(L10n.string("toggle.launch_at_login"), isOn: Binding(
+                    get: { viewModel.launchAtLogin.isEnabled },
+                    set: { newValue in
+                        viewModel.setLaunchAtLogin(newValue)
+                    }
+                ))
+            } header: {
+                Text(L10n.string("settings.section.startup"))
+            }
+
+            if let statusMessage = viewModel.statusMessage {
+                Section {
+                    Text(statusMessage)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .onTapGesture {
+                            viewModel.clearStatusMessage()
+                        }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .frame(minWidth: 420, minHeight: 300)
+    }
+}


### PR DESCRIPTION
## 修复内容

**问题**：`ProcessBarMonitorApp.swift` 中 `Settings { EmptyView() }` 占着系统设置入口但没有任何内容。用户期望通过 macOS 系统设置 → ProcessBarMonitor 来调整偏好，但打开后是空白页。

**修复**：新增 `SettingsView.swift`，将 menu bar 内已实现的偏好项（display mode、temperature mode、process limit、launch at login）抽取为独立的设置界面，并挂到 Settings scene。

### 新增文件
- `Sources/ProcessBarMonitor/SettingsView.swift`：独立的设置视图，包含"显示"和"启动"两个分组，分别对应原有 menu bar 中的偏好项。

### 修改文件
- `ProcessBarMonitorApp.swift`：将 `EmptyView()` 替换为 `SettingsView(viewModel: viewModel)`
- `Resources/en.lproj/Localizable.strings`：增加 `settings.section.display` / `settings.section.startup`
- `Resources/zh-Hans.lproj/Localizable.strings`：增加 `settings.section.display` / `settings.section.startup`

## 影响范围

- 功能新增：系统设置窗口现在有实际内容
- 行为不变：所有偏好项与 menu bar 中已有的完全一致