### PR TITLE
feat: make ProcessSnapshotProvider a singleton actor to persist metadataCache (#18)

### DIFF
--- a/Sources/ProcessBarMonitor/MonitorViewModel.swift
+++ b/Sources/ProcessBarMonitor/MonitorViewModel.swift
@@ -49,7 +49,7 @@ final class MonitorViewModel: ObservableObject {
     }
 
     private let metricsProvider = SystemMetricsProvider()
-    private let processProvider = ProcessSnapshotProvider()
+    private let processProvider = ProcessSnapshotProvider.shared
     private let settings: SettingsStore
     private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "ai.openclaw.ProcessBarMonitor", category: "process-snapshot")
     private var refreshTask: Task<Void, Never>?

--- a/Sources/ProcessBarMonitor/ProcessSnapshotProvider.swift
+++ b/Sources/ProcessBarMonitor/ProcessSnapshotProvider.swift
@@ -2,6 +2,8 @@ import Foundation
 import AppKit
 
 actor ProcessSnapshotProvider {
+    static let shared = ProcessSnapshotProvider()
+
     enum SnapshotError: LocalizedError {
         case launchFailed(Error)
         case commandFailed(status: Int32, stderr: String)


### PR DESCRIPTION
## 修复内容

**问题**：`ProcessSnapshotProvider` 是 `MonitorViewModel` 的实例变量。每次 `MonitorViewModel` 重建（如 App 重启、状态重置），`ProcessSnapshotProvider` 实例也跟着重建，其中持有的 `metadataCache` 全量丢失，导致 macOS 系统进程 PID 需要重新触发 `NSRunningApplication` 查询，开销显著。

**修复**：将 `ProcessSnapshotProvider` 改为全局单例 actor (`static let shared`)，`MonitorViewModel` 改为引用 `ProcessSnapshotProvider.shared`。即使 `MonitorViewModel` 重建，只要 App 进程不退出，`metadataCache` 就持续有效。

```swift
// 修复后：使用单例
actor ProcessSnapshotProvider {
    static let shared = ProcessSnapshotProvider()
    // ...
}

// MonitorViewModel
private let processProvider = ProcessSnapshotProvider.shared
```

## 影响范围

- 功能新增：缓存跨 view model 生命周期持久化
- 行为不变：对外接口和查询结果完全一致
- `metadataCache` 的 30 秒过期 / 按有效 PID 裁剪逻辑不变