### PR TITLE
fix: consolidate settings side effects into MonitorViewModel didSet, remove redundant onChange handlers (issue #32)

### DIFF
--- a/Sources/ProcessBarMonitor/MonitorViewModel.swift
+++ b/Sources/ProcessBarMonitor/MonitorViewModel.swift
@@ -39,13 +39,26 @@ final class MonitorViewModel: ObservableObject {
 
     @Published var searchText = ""
     @Published var processLimit: Int {
-        didSet { settings.set(processLimit, forKey: Keys.processLimit) }
+        didSet {
+            settings.set(processLimit, forKey: Keys.processLimit)
+            // Immediately reflect the new row count in the visible process list.
+            recomputeVisibleProcesses()
+        }
     }
     @Published var temperatureMode: TemperatureMode {
-        didSet { settings.set(temperatureMode.rawValue, forKey: Keys.temperatureMode) }
+        didSet {
+            settings.set(temperatureMode.rawValue, forKey: Keys.temperatureMode)
+            // Immediate refresh ensures the new temperature mode is reflected
+            // without waiting for the next scheduled refresh cycle.
+            Task { await refresh(forceProcesses: true) }
+        }
     }
     @Published var menuBarDisplayMode: MenuBarDisplayMode {
-        didSet { settings.set(menuBarDisplayMode.rawValue, forKey: Keys.menuBarDisplayMode) }
+        didSet {
+            settings.set(menuBarDisplayMode.rawValue, forKey: Keys.menuBarDisplayMode)
+            // Refresh so the menu bar title format update is immediate.
+            Task { await refresh(forceProcesses: false) }
+        }
     }
 
     private let metricsProvider = SystemMetricsProvider()

--- a/Sources/ProcessBarMonitor/SettingsView.swift
+++ b/Sources/ProcessBarMonitor/SettingsView.swift
@@ -24,9 +24,7 @@ struct SettingsView: View {
                     Text("12").tag(12)
                     Text("20").tag(20)
                 }
-                .onChange(of: viewModel.processLimit) { _ in
-                    viewModel.recomputeVisibleProcesses()
-                }
+                // Side-effect (recomputeVisibleProcesses) is in MonitorViewModel.processLimit.didSet
             } header: {
                 Text(L10n.string("settings.section.display"))
             }

--- a/Sources/ProcessBarMonitor/Views.swift
+++ b/Sources/ProcessBarMonitor/Views.swift
@@ -231,9 +231,7 @@ struct MenuBarContentView: View {
                             Text(mode.title).tag(mode)
                         }
                     }
-                    .onChange(of: viewModel.temperatureMode) { _ in
-                        Task { await viewModel.refresh(forceProcesses: true) }
-                    }
+                    // Refresh side-effect is in MonitorViewModel.temperatureMode.didSet
 
                     TextField(L10n.string("search.placeholder"), text: $viewModel.searchText)
                         .textFieldStyle(.roundedBorder)
@@ -248,9 +246,7 @@ struct MenuBarContentView: View {
                         Text("20").tag(20)
                     }
                     .pickerStyle(.segmented)
-                    .onChange(of: viewModel.processLimit) { _ in
-                        viewModel.recomputeVisibleProcesses()
-                    }
+                    // Side-effect (recomputeVisibleProcesses) is in MonitorViewModel.processLimit.didSet
                 }
 
                 Toggle(L10n.string("toggle.launch_at_login"), isOn: Binding(


### PR DESCRIPTION
fix/issue32-settings-behavior-drift