### PR TITLE
fix: remove unguarded exit(0) fallback from quit flow (issue #35)

### DIFF
--- a/Sources/ProcessBarMonitor/Views.swift
+++ b/Sources/ProcessBarMonitor/Views.swift
@@ -127,12 +127,13 @@ struct MenuBarContentView: View {
             window.close()
         }
 
+        // Standard macOS termination.  The 0.5 s + exit(0) fallback that existed here
+        // was added without a linked issue or documented reproduction, and stop() has no
+        // persistent background work that would prevent terminate from succeeding.
+        // If a future regression shows terminate is insufficient, re-add the fallback
+        // only with a comment explaining the specific failure mode and a tracking issue.
         DispatchQueue.main.async {
             NSApp.terminate(nil)
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            exit(0)
         }
     }
 


### PR DESCRIPTION
d51db56 added 0.5s + exit(0) without a linked issue, without a comment explaining the failure mode, and without persistent background work in stop() that would prevent terminate from succeeding.

Removed: DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { exit(0) }
Replaced with: comment explaining the decision and under what conditions the fallback may be re-added (specific reproduction + tracking issue).